### PR TITLE
Adde push style deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,8 +31,11 @@ test:
 #        timeout: 21600
 #    - docker run -ti --rm -v ${HOME}/data/ds114_test2:/bids_dataset -v ${HOME}/outputs2:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 02 :
 #        timeout: 21600
-#deployment:
-#  hub:
-#    branch: master
-#    commands:
-#      - if [[ -n "$DOCKER_PASS" ]]; then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && docker push $DOCKER_REPO; fi
+deployment:
+  hub:
+    branch: master
+    commands:
+      - if [[ -n "$DOCKER_PASS" ]]; then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && docker push bids/${CIRCLE_PROJECT_REPONAME}:latest; fi :
+          timeout: 21600
+      - if [[ -n "$DOCKER_PASS" ]]; then docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS && docker tag bids/${CIRCLE_PROJECT_REPONAME} bids/${CIRCLE_PROJECT_REPONAME}:V$CIRCLE_BUILD_NUM-${CIRCLE_SHA1:0:6} && docker push bids/${CIRCLE_PROJECT_REPONAME}:V$CIRCLE_BUILD_NUM-${CIRCLE_SHA1:0:6}; fi :
+          timeout: 21600


### PR DESCRIPTION
This will push a new uniquely tagged version of ndmg to docker hub. This way users will be able to use (and come back to) a particular version of a container (which is essential for reproducibility).
